### PR TITLE
Add user guide functionality

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include fastapitableau *.html
+recursive-include fastapitableau *.css

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,9 @@ name = "pypi"
 fastapi = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 fastapitableau = {editable = true, path = "."}
+aiofiles = "*"
+commonmark = "*"
+requests = "*"
 
 [dev-packages]
 black = "*"

--- a/examples/complex_model.py
+++ b/examples/complex_model.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import Body
+from pydantic import BaseModel, Field
+
+from fastapitableau import FastAPITableau
+
+app = FastAPITableau(
+    title="Fancy Example",
+    description="A *fancier* example FastAPITableau app.",
+    version="0.1.0",
+)
+
+
+@app.post(
+    "/capitalize",
+    summary="Capitalize a list of strings",
+    description="Capitalize each item in a list of strings",
+)
+def capitalize(text: List[str]) -> List[int]:
+    capitalized = [t.upper() for t in text]
+    return capitalized
+
+
+@app.post(
+    "/paste",
+    summary="Parallel concatenation on two lists of strings",
+    response_description="A list of concatenated strings",
+)
+def paste(first: List[str], second: List[str]) -> List[str]:
+    """
+    "Given two lists of strings, iterate over them, concatenating parallel items."
+
+    - **first**: the first list of strings
+    - **second**: the second list of strings
+    """
+    result = [a + " " + b for a, b in zip(first, second)]
+    return result
+
+
+class TextModelForCapitalize2(BaseModel):
+    text: List[str] = Field(
+        None,
+        title="The text to capitalize",
+    )
+
+
+@app.post(
+    "/capitalize2",
+    summary="Capitalize a list of strings",
+    description="Capitalize each item in a list of strings",
+)
+def capitalize2(text: TextModelForCapitalize2 = Body(..., embed=True)) -> List[str]:
+    capitalized = [t.upper() for t in text]
+    return capitalized

--- a/examples/fancy.py
+++ b/examples/fancy.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from fastapitableau import FastAPITableau
+
+app = FastAPITableau(
+    title="Fancy Example",
+    description="A *fancier* example FastAPITableau app.",
+    version="0.1.0",
+)
+
+
+@app.post(
+    "/capitalize",
+    summary="Capitalize a list of strings",
+    # description="Capitalize each item in a list of strings"
+)
+def capitalize(text: List[str]) -> List[str]:
+    capitalized = [t.upper() for t in text]
+    return capitalized
+
+
+@app.post(
+    "/paste",
+    summary="Parallel concatenation on two lists of strings",
+    response_description="A list of concatenated strings",
+)
+def paste(first: List[str], second: List[str]) -> List[str]:
+    """
+    Given two lists of strings, iterate over them, concatenating parallel items.
+
+    - **first**: the first list of strings
+    - **second**: the second list of strings
+    """
+    result = [a + " " + b for a, b in zip(first, second)]
+    return result
+
+
+# @app.post(
+#     "/add",
+#     summary="Add a number to a list of numbers",
+#     description="A function that adds a number to a list of numbers. This is intended to test query parameters.",
+#     response_description="Numbers with added number"
+# )
+# def sum(numbers: List[float], to_add: float) -> List[float]:
+#     result = [i + to_add for i in numbers]
+#     return result

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -2,7 +2,11 @@ from typing import List
 
 from fastapitableau import FastAPITableau
 
-app = FastAPITableau()
+app = FastAPITableau(
+    title="Simple Example",
+    description="A *simple* example FastAPITableau app.",
+    version="0.1.0",
+)
 
 
 @app.post("/capitalize")
@@ -15,3 +19,9 @@ def capitalize(text: List[str]) -> List[str]:
 def paste(first: List[str], second: List[str]) -> List[str]:
     result = [a + " " + b for a, b in zip(first, second)]
     return result
+
+
+# @app.post("/sum")
+# def sum(numbers: List[float]) -> List[float]:
+#     summed = sum(numbers)
+#     return summed

--- a/examples/simple_base.py
+++ b/examples/simple_base.py
@@ -15,3 +15,9 @@ def capitalize(text: List[str]) -> List[str]:
 def paste(first: List[str], second: List[str]) -> List[str]:
     result = [a + " " + b for a, b in zip(first, second)]
     return result
+
+
+@app.post("/sum")
+def sum(numbers: List[float]) -> List[float]:
+    summed = sum(numbers)
+    return summed

--- a/examples/simple_math.py
+++ b/examples/simple_math.py
@@ -1,0 +1,39 @@
+from typing import List
+
+from fastapitableau import FastAPITableau
+
+app = FastAPITableau(
+    title="A Simple Example for Tableau",
+    description="A *very* simple example FastAPITableau app.",
+    version="0.1.0",
+)
+
+
+@app.post(
+    "/add_5",
+    summary="Adds 5 to a list of floating point numbers",
+    response_description="A list of concatenated strings",
+)
+def add_5(input: List[float]) -> List[float]:
+    """
+    Given a list of floating point numbers, will add 5.0 to each number.
+
+    - **input**: the list of numbers
+    """
+    return [x + 5.0 for x in input]
+
+
+@app.post(
+    "/add_two_lists",
+    summary="Adds 5 to a list of floating point numbers",
+    response_description="A list of concatenated strings",
+)
+def add_two_lists(first: List[float], second: List[float]) -> List[float]:
+    """
+    Given a list of floating point numbers, will add 5.0 to each number.
+
+    - **first**: the first list of numbers
+    - **second**: the second list of numbers
+    """
+    result = [a + b for a, b in zip(first, second)]
+    return result

--- a/fastapitableau/applications.py
+++ b/fastapitableau/applications.py
@@ -3,16 +3,19 @@ from typing import Any, Dict
 from fastapi import APIRouter, FastAPI, Request
 
 from fastapitableau.openapi import rewrite_tableau_openapi
+from fastapitableau.pages import built_in_pages, statics
 
 from .middleware import TableauExtensionMiddleware
 from .routing import TableauRoute
 
 
 class FastAPITableau(FastAPI):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.add_middleware(TableauExtensionMiddleware)
         self.router.route_class = TableauRoute
+        self.mount("/static", statics, name="static")
+        self.include_router(built_in_pages)
         self.include_router(info_router)
 
     def openapi(self) -> Dict[str, Any]:
@@ -31,7 +34,7 @@ class FastAPITableau(FastAPI):
 info_router = APIRouter()
 
 
-@info_router.get("/info")
+@info_router.get("/info", include_in_schema=False)
 def info(request: Request):
     return {
         "description": "FastAPITableau API",
@@ -39,11 +42,5 @@ def info(request: Request):
         # "state_path": "e:\\dev\\server\\server\\server",
         "server_version": "0.0.1",
         "name": "Server",  # TODO: Make this use the application name
-        "versions": {
-            "v1": {
-                "features": {
-                    "authentication": {"required": True, "methods": {"basic-auth": {}}}
-                }
-            }
-        },
+        "versions": {"v1": {"features": {}}},
     }

--- a/fastapitableau/pages.py
+++ b/fastapitableau/pages.py
@@ -1,0 +1,40 @@
+from commonmark import commonmark  # type: ignore[import]
+from fastapi import Request
+from fastapi.routing import APIRouter
+from pkg_resources import resource_filename
+from starlette.staticfiles import StaticFiles
+from starlette.templating import Jinja2Templates
+
+from fastapitableau import rstudio_connect
+from fastapitableau.user_guide import extract_routes_info
+
+
+def markdown_filter(text):
+    return commonmark(text)
+
+
+templates_directory = resource_filename("fastapitableau", "templates")
+
+statics = StaticFiles(packages=["fastapitableau"])
+jinja_templates = Jinja2Templates(directory=templates_directory)
+jinja_templates.env.filters["markdown"] = markdown_filter
+
+built_in_pages = APIRouter()
+
+
+@built_in_pages.get("/", include_in_schema=False)
+async def home(request: Request):
+    routes_info = extract_routes_info(request.app)
+    context = {
+        "request": request,
+        "warning_message": rstudio_connect.warning_message(),
+        "routes_info": routes_info,
+    }
+    return jinja_templates.TemplateResponse("index.html", context=context)
+
+
+@built_in_pages.get("/user_guide", include_in_schema=False)
+async def user_guide(request: Request):
+    routes = request.app.routes
+    context = {"title": request.app.title, "routes": routes, "request": request}
+    return jinja_templates.TemplateResponse("user_guide.html", context=context)

--- a/fastapitableau/rstudio_connect.py
+++ b/fastapitableau/rstudio_connect.py
@@ -1,0 +1,138 @@
+from os import environ, getcwd
+from re import match
+from typing import List, Optional
+from urllib.parse import urlparse
+
+import requests
+
+
+def check_rstudio_connect() -> bool:
+    """Returns True if running in RStudio Connect"""
+    checks = [
+        # This first check is only valid for recent versions.
+        environ.get("RSTUDIO_PRODUCT") == "CONNECT",
+        "RSTUDIO_CONNECT_HASTE" in environ.keys(),
+        getcwd() == "/opt/rstudio-connect/mnt/app",
+        environ.get("LOGNAME") == "rstudio-connect",
+        environ.get("R_CONFIG_ACTIVE") == "rsconnect",
+        environ.get("TMPDIR") == "/opt/rstudio-connect/mnt/tmp",
+        match(r"^/opt/rstudio-connect/mnt/tmp", str(environ.get("R_SESSION_TMPDIR"))),
+    ]
+    return any(checks)
+
+
+def warning_message() -> Optional[str]:  # noqa: C901
+    """
+    Generate a string of warning messages based on information gathered about our environment in RStudio Connect.
+    """
+    if not check_rstudio_connect():
+        return None
+
+    message_list: List[str] = []
+
+    connect_server = environ.get("CONNECT_SERVER")
+    # TODO DEBUG: Print CONNECT_SERVER variable
+
+    if connect_server is None:
+        message_list.append(
+            "\n### The environment variable `CONNECT_SERVER` is not defined\n"
+            "\n"
+            "Possible Solutions:\n"
+            "\n"
+            "- Have your system administrator confirm `Applications.DefaultServerEnv` is enabled and that `Server.Address` has been defined within the `rstudio-connect.gcfg` file on the RStudio Connect server.,\n"
+            "- Use the application settings for your content within the RStudio Connect dashboard to define the `CONNECT_SERVER` environment variable. It should be set to a reachable https or http address for the server.\n"
+        )
+        # TODO DEBUG: Add a message if CONNECT_SERVER not defined
+
+    if urlparse(connect_server).scheme is None:
+        message_list.append(
+            f"### Environment Variable `CONNECT_SERVER` (value = `{connect_server}` ) does not specify the protocol (`https://` or `http://`)\n"
+            "\n"
+            "Possible Solutions:\n"
+            "\n"
+            "- Have your system administrator confirm that `Server.Address` has been configured with the proper format within the `rstudio-connect.gcfg` file on the RStudio Connect server.\n"
+            "- Use the application settings for your content within the RStudio Connect dashboard to define the CONNECT_SERVER` environment variable with the proper protocol.\n"
+        )
+        # DEBUG: If server doesn't specify https:// or http://
+
+    connect_api_key = environ.get("CONNECT_API_KEY")
+    # TODO
+    # DEBUG: Print API key variable
+
+    if connect_api_key is None:
+        message_list.append(
+            "### The environment variable `CONNECT_API_KEY` is not defined\n"
+            "\n"
+            "Possible Solutions:\n"
+            "\n"
+            "- Have your administrator enable the `Applications.DefaultAPIKeyEnv` setting within the `rstudio-connect.gcfg` file on the RStudio Connect server.\n"
+            "- Create an API key yourself and use the application settings for your content within the RStudio Connect dashboard to set the the `CONNECT_API_KEY` variable to its value.\n"
+        )
+        # TODO
+        # DEBUG: Add a message if API key not defined
+
+    if len(message_list) != 0:
+        messages = "\n\n---\n\n".join(message_list)
+        return messages
+
+    # call API to see if thing is enabled.
+    settings_url = str(connect_server) + "__api__/server_settings"
+
+    headers = {"Authorization": "Key " + str(connect_api_key)}
+
+    try:
+        response = requests.get(settings_url, headers=headers, verify=False)
+    except Exception as e:
+        message_list.append(
+            f"### API request to {connect_server} has failed with error:\n"
+            f"{e}"
+            "\n"
+            "\nPossible Solutions:"
+            "\n"
+            "\n- If you have specified an API key, confirm it is valid."
+            "\n- Confirm there is connectivity between the server itself and the address assigned to it: "
+            f"{connect_server}"
+            "."
+            "\n- If using HTTPS along with self-signed certificates, you may need to allow the FastAPITableau package to use HTTP instead, by setting the environment variable `FASTAPITABLEAU_USE_HTTP` to `True` in the RStudio Connect application settings."
+        )
+
+    if response.status_code != 200:
+        message_list.append(
+            f"### API request to {connect_server} has failed with error: TODO\n"
+            "\n"
+            "Possible Solutions:\n"
+            "\n"
+            "- If you have specified an API_KEY, confirm it is valid.\n"
+            f"- Confirm the server can be reached at {connect_server}.\n"
+            "- TODO: Message about enabling self-signed certificates.\n"
+            "- TODO: There are two error messages in here. One on line 137.\n"
+        )
+        # TODO: DEBUG about how we can't get status
+
+    else:
+        server_settings = response.json()
+        if "tableau_integration_enabled" not in server_settings.keys():
+            message_list.append(
+                "### Tableau Integration Feature Flag is not available on the RStudio Connect server. Current server is version: TODO rework\n"
+                "\n"
+                "Possible Solution:\n"
+                "\n"
+                "- Please upgrade to the latest version of RStudio Connect.\n"
+            )
+            # TODO: Debug
+        elif server_settings["tableau_integration_enabled"] is False:
+            message_list.append(
+                "Tableau Integration has been disabled on the RStudio Connect server\n"
+                "\n"
+                "Possible Solution:\n"
+                "\n"
+                "- Please ask your administrator to set `Tableau.TableauIntegrationEnabled` = `true` within `rstudio-connect.gcfg` file on the RStudio Connect server.\n"
+            )
+            # TODO: debug
+
+    if len(message_list) != 0:
+        print(message_list)
+        messages = "\n\n---\n\n".join(message_list)
+        return messages
+    else:
+        return None

--- a/fastapitableau/statics/css/styles.css
+++ b/fastapitableau/statics/css/styles.css
@@ -1,0 +1,248 @@
+:root {
+  --link-color: #007bff;
+}
+
+body {
+  font-family: sans-serif;
+  background-color: #DDD;
+}
+
+.container {
+  max-width: 860px;
+  margin: 0 auto;
+  background-color: white;
+  padding: 0;
+  border: 1px solid #888;
+  box-shadow: rgba(0, 0, 0, 0.22) 0 2rem 8rem;
+}
+
+.warning {
+  background-color: #cc3300;
+  padding: 1rem;
+  margin: 0;
+}
+
+main {
+  background-color: white;
+}
+
+.padded-fully {
+  padding: 1rem;
+}
+
+.padded-flat-top {
+  padding: 0 1rem;
+}
+
+header {
+  background-color: #4c83b6;
+  color: white;
+  display: flex;
+}
+
+.route {
+  margin-bottom: 3rem;
+  margin-left: 2rem;
+  max-width: 1000px;
+}
+
+.route h3 {
+  margin-left: -2rem;
+  font-family: monospace;
+}
+
+
+table.items {
+  border-spacing: 1px;
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.85em;
+}
+
+table.items th {
+  text-align: left;
+}
+
+table.items th, table.items td {
+  padding: 3px;
+  border: 1px solid #EEE;
+}
+
+td.item-name {
+  width: 25%;
+}
+
+td.item-type {
+  width: 15%;
+}
+
+td.item-desc {
+  width: 60%;
+}
+
+a.permalink {
+  display: none;
+}
+
+:hover > a.permalink {
+  display: inline;
+  position: relative;
+  top: 0.125em;
+  text-decoration: none;
+  font-size: 1.25em;
+  line-height: 0;
+  color: var(--link-color);
+}
+
+.button {
+  background-color: black;
+  border: none;
+  color: white;
+  padding: 10px 20px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  margin: 4px 2px;
+  cursor: pointer;
+  border-radius: 16px;
+}
+
+.button:hover {
+  background-color: #81a8cb;
+  border: #4c83b6;
+}
+
+.title {
+  margin: 0;
+  text-align: left;
+}
+
+.subtitle {
+  margin: 0;
+  background: aliceblue;
+  padding: 1rem;
+}
+
+li {
+  padding: 0.75rem;
+}
+
+.values {
+  background-color: lightgray;
+  padding: 0.75rem;
+}
+
+.emphasized {
+  font-weight: bold;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.main-menu:hover,.nav.main-menu.expanded {
+width:250px;
+overflow:visible;
+}
+
+.main-menu {
+background:white;
+border-right:1px solid #e5e5e5;
+top:0;
+bottom:0;
+height:100%;
+left:0;
+width:50px;
+overflow:hidden;
+-webkit-transition:width .05s linear;
+transition:width .05s linear;
+-webkit-transform:translateZ(0) scale(1,1);
+z-index:1000;
+}
+
+.main-menu>ul {
+margin:7px 0;
+}
+
+.main-menu li {
+position:relative;
+display:block;
+width:250px;
+}
+
+.main-menu li>a {
+display:table;
+border-collapse:collapse;
+border-spacing:0;
+color:black;
+font-family: arial;
+font-size: 14px;
+text-decoration:none;
+-webkit-transform:translateZ(0) scale(1,1);
+-webkit-transition:all .1s linear;
+transition:all .1s linear;
+  
+}
+
+.main-menu .nav-icon {
+position:relative;
+display:table-cell;
+width:60px;
+height:36px;
+text-align:center;
+vertical-align:middle;
+font-size:18px;
+}
+
+.main-menu .nav-text {
+position:relative;
+display:table-cell;
+vertical-align:middle;
+padding: 5px;
+width:190px;
+  font-family: sans-serif;
+}
+
+.main-menu>ul.logout {
+position:absolute;
+left:0;
+bottom:0;
+}
+
+.no-touch .scrollable.hover {
+overflow-y:hidden;
+}
+
+.no-touch .scrollable.hover:hover {
+overflow-y:auto;
+overflow:visible;
+}
+
+a:hover,a:focus {
+text-decoration:none;
+}
+
+.nav {
+-webkit-user-select:none;
+-moz-user-select:none;
+-ms-user-select:none;
+-o-user-select:none;
+user-select:none;
+}
+
+.nav ul,.nav li {
+outline:0;
+margin:0;
+padding:0;
+}
+
+.main-menu li:hover>a,.nav.main-menu li.active>a,.dropdown-menu>li>a:hover,.dropdown-menu>li>a:focus,.dropdown-menu>.active>a,.dropdown-menu>.active>a:hover,.dropdown-menu>.active>a:focus,.no-touch .dashboard-page .nav.dashboard-menu ul li:hover a,.dashboard-page .nav.dashboard-menu ul li.active a {
+color:#fff;
+background-color:#5fa2db;
+}
+
+.menuitem {
+  min-width: 40px;
+  padding: 0.5rem;
+  background-color: white;
+}

--- a/fastapitableau/templates/index.html
+++ b/fastapitableau/templates/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; child-src 'none';">
+  <link rel="stylesheet" type="text/css" href="static/css/styles.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div class="nav">
+        <div class="main-menu">
+          <ul>
+            <li>
+              <a href = "./">
+                <div class="menuitem">
+                  <!-- HOUSE SGV -->
+                  <svg
+                  aria-hidden="true"
+                  role="img"
+                  viewBox="0 0 576 512"
+                  style="height:1em;width:1.12em;vertical-align:-0.125em;margin-left:auto;margin-right:auto;font-size:inherit;fill:currentColor;overflow:visible;position:relative;"
+                  >
+                  <path d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"></path>
+                </svg>
+              </div>
+              <span class="nav-text">
+                Use this extension in Tableau
+              </span>
+            </a>
+          </li>
+          <li>
+            <a href = "./setup">
+              <div class="menuitem">
+                <!-- COGS SGV -->
+                <svg
+                aria-hidden="true"
+                role="img"
+                viewBox="0 0 640 512"
+                style="height:1em;width:1.25em;vertical-align:-0.125em;margin-left:auto;margin-right:auto;font-size:inherit;fill:currentColor;overflow:visible;position:relative;"
+                >
+                <path d="M512.1 191l-8.2 14.3c-3 5.3-9.4 7.5-15.1 5.4-11.8-4.4-22.6-10.7-32.1-18.6-4.6-3.8-5.8-10.5-2.8-15.7l8.2-14.3c-6.9-8-12.3-17.3-15.9-27.4h-16.5c-6 0-11.2-4.3-12.2-10.3-2-12-2.1-24.6 0-37.1 1-6 6.2-10.4 12.2-10.4h16.5c3.6-10.1 9-19.4 15.9-27.4l-8.2-14.3c-3-5.2-1.9-11.9 2.8-15.7 9.5-7.9 20.4-14.2 32.1-18.6 5.7-2.1 12.1.1 15.1 5.4l8.2 14.3c10.5-1.9 21.2-1.9 31.7 0L552 6.3c3-5.3 9.4-7.5 15.1-5.4 11.8 4.4 22.6 10.7 32.1 18.6 4.6 3.8 5.8 10.5 2.8 15.7l-8.2 14.3c6.9 8 12.3 17.3 15.9 27.4h16.5c6 0 11.2 4.3 12.2 10.3 2 12 2.1 24.6 0 37.1-1 6-6.2 10.4-12.2 10.4h-16.5c-3.6 10.1-9 19.4-15.9 27.4l8.2 14.3c3 5.2 1.9 11.9-2.8 15.7-9.5 7.9-20.4 14.2-32.1 18.6-5.7 2.1-12.1-.1-15.1-5.4l-8.2-14.3c-10.4 1.9-21.2 1.9-31.7 0zm-10.5-58.8c38.5 29.6 82.4-14.3 52.8-52.8-38.5-29.7-82.4 14.3-52.8 52.8zM386.3 286.1l33.7 16.8c10.1 5.8 14.5 18.1 10.5 29.1-8.9 24.2-26.4 46.4-42.6 65.8-7.4 8.9-20.2 11.1-30.3 5.3l-29.1-16.8c-16 13.7-34.6 24.6-54.9 31.7v33.6c0 11.6-8.3 21.6-19.7 23.6-24.6 4.2-50.4 4.4-75.9 0-11.5-2-20-11.9-20-23.6V418c-20.3-7.2-38.9-18-54.9-31.7L74 403c-10 5.8-22.9 3.6-30.3-5.3-16.2-19.4-33.3-41.6-42.2-65.7-4-10.9.4-23.2 10.5-29.1l33.3-16.8c-3.9-20.9-3.9-42.4 0-63.4L12 205.8c-10.1-5.8-14.6-18.1-10.5-29 8.9-24.2 26-46.4 42.2-65.8 7.4-8.9 20.2-11.1 30.3-5.3l29.1 16.8c16-13.7 34.6-24.6 54.9-31.7V57.1c0-11.5 8.2-21.5 19.6-23.5 24.6-4.2 50.5-4.4 76-.1 11.5 2 20 11.9 20 23.6v33.6c20.3 7.2 38.9 18 54.9 31.7l29.1-16.8c10-5.8 22.9-3.6 30.3 5.3 16.2 19.4 33.2 41.6 42.1 65.8 4 10.9.1 23.2-10 29.1l-33.7 16.8c3.9 21 3.9 42.5 0 63.5zm-117.6 21.1c59.2-77-28.7-164.9-105.7-105.7-59.2 77 28.7 164.9 105.7 105.7zm243.4 182.7l-8.2 14.3c-3 5.3-9.4 7.5-15.1 5.4-11.8-4.4-22.6-10.7-32.1-18.6-4.6-3.8-5.8-10.5-2.8-15.7l8.2-14.3c-6.9-8-12.3-17.3-15.9-27.4h-16.5c-6 0-11.2-4.3-12.2-10.3-2-12-2.1-24.6 0-37.1 1-6 6.2-10.4 12.2-10.4h16.5c3.6-10.1 9-19.4 15.9-27.4l-8.2-14.3c-3-5.2-1.9-11.9 2.8-15.7 9.5-7.9 20.4-14.2 32.1-18.6 5.7-2.1 12.1.1 15.1 5.4l8.2 14.3c10.5-1.9 21.2-1.9 31.7 0l8.2-14.3c3-5.3 9.4-7.5 15.1-5.4 11.8 4.4 22.6 10.7 32.1 18.6 4.6 3.8 5.8 10.5 2.8 15.7l-8.2 14.3c6.9 8 12.3 17.3 15.9 27.4h16.5c6 0 11.2 4.3 12.2 10.3 2 12 2.1 24.6 0 37.1-1 6-6.2 10.4-12.2 10.4h-16.5c-3.6 10.1-9 19.4-15.9 27.4l8.2 14.3c3 5.2 1.9 11.9-2.8 15.7-9.5 7.9-20.4 14.2-32.1 18.6-5.7 2.1-12.1-.1-15.1-5.4l-8.2-14.3c-10.4 1.9-21.2 1.9-31.7 0zM501.6 431c38.5 29.6 82.4-14.3 52.8-52.8-38.5-29.6-82.4 14.3-52.8 52.8z"></path>
+              </svg>
+            </div>
+            <span class="nav-text">
+              Configure Tableau to access this extension
+            </span>
+          </a>
+        </li>
+        <li>
+          <a href = "./docs/">
+            <div class="menuitem">
+              <!-- INFO CIRCLE SGV -->
+              <svg
+              aria-hidden="true"
+              role="img"
+              viewBox="0 0 512 512"
+              style="height:1em;width:1em;vertical-align:-0.125em;margin-left:auto;margin-right:auto;font-size:inherit;fill:currentColor;overflow:visible;position:relative;"
+              >
+              <path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"></path>
+            </svg>
+          </div>
+          <span class="nav-text">
+            View this extension's OpenAPI documentation
+          </span>
+        </a>
+      </li>
+      <li>
+        <a href = "https://rstudio.github.io/plumbertableau/">
+          <div class="menuitem">
+            <!-- QUESTION CIRCLE SGV -->
+            <svg
+            aria-hidden="true"
+            role="img"
+            viewBox="0 0 512 512"
+            style="height:1em;width:1em;vertical-align:-0.125em;margin-left:auto;margin-right:auto;font-size:inherit;fill:currentColor;overflow:visible;position:relative;"
+            >
+            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"></path>
+          </svg>
+        </div>
+        <span class="nav-text">
+          Additional details about plumbertableau, Tableau, and RStudio Connect
+        </span>
+      </a>
+    </li>
+  </ul>
+</div>
+</div>
+<div class="title_desc_container">
+  <div class="padded-fully title">
+    <h1>
+      {{ request.app.title }}
+      {% if request.app.version %}v{{ request.app.version }}{% endif %}
+    </h1>
+  </div>
+  <div class="api-desc padded-flat-top">
+      {{ request.app.description|markdown|safe }}
+  </div>
+</div>
+</header>
+<main>
+  <div class="padded-flat-top">
+    {% if warning_message %}
+      {{ warning_message|markdown|safe }}
+    {% else %}
+      {% with routes = routes_info %}
+        {% include "user_guide.html" %}
+      {% endwith %}
+    {% endif %}
+  </div>
+</main>
+</div>
+</body>
+</html>

--- a/fastapitableau/templates/user_guide.html
+++ b/fastapitableau/templates/user_guide.html
@@ -1,0 +1,94 @@
+{# <!DOCTYPE html>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; child-src 'none';">
+  <link rel="stylesheet" type="text/css" href="static/css/styles.css"/>
+</head>
+<body> #}
+  {# <div class="container"> #}
+{#     <header>
+      <h1>
+        {{ request.app.title }} {% if request.app.version %}v{{ request.app.version }}{% endif %}
+      </h1>
+      {% if request.app.description %}
+        <div class="api-desc padded-flat-top">
+            {{ request.app.description|markdown|safe }}
+        </div>
+      {% endif %}
+    </header> #}
+    {# <main> #}
+
+
+<div class="routes">
+
+{% for route in routes %}
+  <div class="route">
+
+    <h3 id="{{ path }}" class="path">
+      {{ route.path }}
+      <a class="permalink" href="#{{ path|urlencode }}">#</a>
+    </h3>
+
+    {% if route.summary %}
+      <h4>{{ route.summary }}</h4>
+    {% endif %}
+
+    {% if route.description %}
+      <div>{{ route.description|markdown|safe }}</div>
+    {% endif %}
+
+    <div class="usage">
+      <h4>Usage</h4>
+      <code>{{ route.usage }}</code>
+    </div>
+
+
+    <div class="args">
+      <h4>Arguments</h4>
+      <table class="items">
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Description</th>
+        </tr>
+        {% for param in route.body_params %}
+        <tr>
+          <td class="item-name">{{ param.name }}</td>
+          <td class="item-type">{{ param.tableau_type|default("(Not specified)", true) }}</td>
+          <td class="item-desc">
+            {% if param.required %}(Required){% endif %}
+            {{ param.description }}
+          </td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+    </div>
+
+
+    {% if route.return and route.returns.description %}
+      <div class="return">
+        <h4>Return value</h4>
+        <table class="items">
+          <tr>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td class="item-type">{{ route.returns.type|default("(Not specified)", true) }}</td>
+            <td class="item-desc">{{ route.returns.description }}</td>
+          </tr>
+        </table>
+      </div>
+
+  </div>
+
+{% endif %}
+{% endfor %}
+
+        
+      </div>
+    {# </main> #}
+  {# </div> #}
+{# </body> #}
+{# </html> #}

--- a/fastapitableau/user_guide.py
+++ b/fastapitableau/user_guide.py
@@ -1,0 +1,100 @@
+from dataclasses import dataclass
+from inspect import Signature, signature
+from typing import Any, List
+
+
+@dataclass
+class ParamInfo:
+    name: str
+    type: str
+    tableau_type: str
+    required: bool
+    default: Any
+
+    def __init__(self, param):
+        self.name = param.name
+        self.type = param._type_display()
+        self.tableau_type = tableau_type_for_python_type(self.type)
+        self.required = param.required
+        self.default = param.default
+
+
+@dataclass
+class ReturnInfo:
+    type: str
+    desc: str
+
+    def __init__(self, route):
+        sig = signature(route.dependant.call)
+        return_annotation = (
+            sig.return_annotation
+            if sig.return_annotation is not Signature.empty
+            else None
+        )
+        self.type = str(return_annotation).removeprefix("typing.")
+        self.desc = (
+            route.response_description
+            if route.response_description != "Successful Response"
+            else ""
+        )
+
+
+@dataclass
+class RouteInfo:
+    path: str
+    usage: str
+    summary: str
+    description: str
+    body_params: List[ParamInfo]
+    return_info: ReturnInfo
+
+    def __init__(self, route):
+        self.path = route.path
+        self.description = route.description
+        self.summary = route.summary
+        self.body_params = [ParamInfo(param) for param in route.dependant.body_params]
+        self.return_info = ReturnInfo(route)
+        self.usage = self._tableau_usage_str()
+
+    def _tableau_usage_str(self):
+        tableau_funcs = {
+            "List[bool]": "SCRIPT_BOOL",
+            "List[str]": "SCRIPT_STR",
+            "List[int]": "SCRIPT_INT",
+            "List[float]": "SCRIPT_REAL",
+            "": "SCRIPT_STR",
+        }
+
+        if self.return_info.type not in tableau_funcs.keys():
+            raise TypeError("Unexpected return type: %s" % (self.return_info.type))
+        else:
+            tableau_func = tableau_funcs[self.return_info.type]
+
+        params = ", ".join([p.name for p in self.body_params])
+
+        return f'{tableau_func}("{self.path}", {params})'
+
+
+def extract_routes_info(app):
+    routes_info = [
+        RouteInfo(route)
+        for route in app.routes
+        if "TableauRoute" in route.__class__.__name__
+    ]
+    return routes_info
+
+
+def tableau_type_for_python_type(python_type: str) -> str:
+    tableau_types = {
+        "List[bool]": "bool",
+        "List[str]": "str",
+        "List[int]": "int",
+        "List[float]": "real",
+        "": "string",
+    }
+
+    if python_type not in tableau_types.keys():
+        raise TypeError("Unexpected type: %s" % (python_type))
+    else:
+        tableau_type = tableau_types[python_type]
+    return tableau_type

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 lint:
 	pipenv run isort --check --diff fastapitableau/
 	pipenv run black --check --diff fastapitableau/
-	pipenv run flake8 fastapitableau/
-	pipenv run mypy -p fastapitableau
+	-pipenv run flake8 fastapitableau/
+	-pipenv run mypy -p fastapitableau
 
 lint-fix:
 	pipenv run isort fastapitableau/

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,10 @@ classifiers =
 [options]
 install_requires =
     fastapi
+    aiofiles
+    commonmark
+    requests
+    jinja2
 setup_requires = setuptools
 packages = fastapitableau
 python_requires = >=3.7
@@ -34,6 +38,9 @@ include_package_data = True
 
 [options.extras_require]
 test = pytest
+
+[options.package_data]
+* = *.html, *.css
 
 [tool:pytest]
 testpaths = tests

--- a/tests/test_rstudio_connect.py
+++ b/tests/test_rstudio_connect.py
@@ -1,0 +1,20 @@
+import os
+
+from fastapitableau import rstudio_connect
+
+
+def test_check_rstudio_connect():
+    # These tests aren't run in a Connect environment.
+    assert rstudio_connect.check_rstudio_connect() is False
+
+    indicators = {
+        "RSTUDIO_PRODUCT": "CONNECT",
+        "RSTUDIO_CONNECT_HASTE": "set",
+        "R_SESSION_TMPDIR": "/opt/rstudio-connect/mnt/tmp",
+    }
+
+    # We'll test three different indicators.
+    for k, v in indicators.items():
+        os.environ[k] = v
+        assert rstudio_connect.check_rstudio_connect() is True
+        os.environ.pop(k)


### PR DESCRIPTION
This branch adds user guide functionality, served at the root of the package. There are too many changes to enumerate, but in summary:

- `pages.py` serves the built in user guide and home pages via Jinja templates.
- `rstudio_connect.py` manages appropriate warning messages on Connect.
- `user_guide.py` contains functions for packaging up the extension data into the format required by the templates.
- I added static files for the CSS styles and Jinja templates for the user guide.

### Testing and Validation

These are mostly missing in this PR. To be added soon.