### PR TITLE
Initial implementation of Tableau-friendly exception handlers

### DIFF
--- a/examples/fancy.py
+++ b/examples/fancy.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from fastapi import HTTPException
+
 from fastapitableau import FastAPITableau
 
 app = FastAPITableau(
@@ -35,12 +37,21 @@ def paste(first: List[str], second: List[str]) -> List[str]:
     return result
 
 
-# @app.post(
-#     "/add",
-#     summary="Add a number to a list of numbers",
-#     description="A function that adds a number to a list of numbers. This is intended to test query parameters.",
-#     response_description="Numbers with added number"
-# )
-# def sum(numbers: List[float], to_add: float) -> List[float]:
-#     result = [i + to_add for i in numbers]
-#     return result
+@app.post(
+    "/add",
+    summary="Add a number to a list of numbers",
+    description="A function that adds a number to a list of numbers. This is intended to test query parameters.",
+    response_description="Numbers with added number",
+)
+def sum(numbers: List[float], to_add: float) -> List[float]:
+    result = [i + to_add for i in numbers]
+    return result
+
+
+@app.post(
+    "/fail",
+    summary="Fails and raises an HTTP Exception",
+    # description="Capitalize each item in a list of strings"
+)
+def fail(text: List[str]) -> None:
+    raise HTTPException(status_code=420, detail="This didn't work")

--- a/examples/simple-curl.sh
+++ b/examples/simple-curl.sh
@@ -43,6 +43,18 @@ curl -X 'POST' \
 -H 'accept: application/json' \
 -H 'Content-Type: application/json' \
 -d '{
+        "script": "/capitalize",
+        "data": {   
+                "arg1_": ["dog", "cat", "rabbit"]
+        }
+}'
+
+
+curl -X 'POST' \
+'http://127.0.0.1:8000/evaluate' \
+-H 'accept: application/json' \
+-H 'Content-Type: application/json' \
+-d '{
         "script": "/paste",
         "data": {   
                 "arg1_": ["Toph", "Bill", "James"],
@@ -59,7 +71,7 @@ curl -X 'POST' \
 -H 'accept: application/json' \
 -H 'Content-Type: application/json' \
 -d '{
-        "first": ["Toph", "Bill", "James"],
+        "first": ["Toph", "Bill", "James"]
 }'
 
 

--- a/fastapitableau/applications.py
+++ b/fastapitableau/applications.py
@@ -36,7 +36,6 @@ class FastAPITableau(FastAPI):
         ] = tableau_request_validation_exception_handler
         self.exception_handlers[Exception] = tableau_general_exception_handler
         self.middleware_stack = self.build_middleware_stack()
-        print(self.middleware_stack)
 
     def openapi(self) -> Dict[str, Any]:
         orig_desc = self.description

--- a/fastapitableau/applications.py
+++ b/fastapitableau/applications.py
@@ -1,7 +1,14 @@
 from typing import Any, Dict
 
 from fastapi import APIRouter, FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException
 
+from fastapitableau.exception_handlers import (
+    tableau_general_exception_handler,
+    tableau_http_exception_handler,
+    tableau_request_validation_exception_handler,
+)
 from fastapitableau.openapi import rewrite_tableau_openapi
 from fastapitableau.pages import built_in_pages, statics
 
@@ -21,6 +28,15 @@ class FastAPITableau(FastAPI):
         self.use_tableau_api_schema = False
         if not self.description:
             self.description = "Description not provided"
+
+        # Add exception handlers
+        self.exception_handlers[HTTPException] = tableau_http_exception_handler
+        self.exception_handlers[
+            RequestValidationError
+        ] = tableau_request_validation_exception_handler
+        self.exception_handlers[Exception] = tableau_general_exception_handler
+        self.middleware_stack = self.build_middleware_stack()
+        print(self.middleware_stack)
 
     def openapi(self) -> Dict[str, Any]:
         orig_desc = self.description

--- a/fastapitableau/exception_handlers.py
+++ b/fastapitableau/exception_handlers.py
@@ -35,7 +35,7 @@ async def tableau_request_validation_exception_handler(
         status_code=HTTP_422_UNPROCESSABLE_ENTITY,
         content={
             "message": f"Server Error: {type(exc).__name__}",
-            "info": {str(exc)},
+            "info": str(exc),
         },
     )
 
@@ -47,6 +47,6 @@ async def tableau_general_exception_handler(
         status_code=HTTP_400_BAD_REQUEST,
         content={
             "message": f"Server Error: {type(exc).__name__}",
-            "info": {str(exc)},
+            "info": str(exc),
         },
     )

--- a/fastapitableau/exception_handlers.py
+++ b/fastapitableau/exception_handlers.py
@@ -41,7 +41,7 @@ async def tableau_request_validation_exception_handler(
 
 
 async def tableau_general_exception_handler(
-    request: Request, exc: HTTPException
+    request: Request, exc: Exception
 ) -> JSONResponse:
     return JSONResponse(
         status_code=HTTP_400_BAD_REQUEST,

--- a/fastapitableau/exception_handlers.py
+++ b/fastapitableau/exception_handlers.py
@@ -1,0 +1,52 @@
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_422_UNPROCESSABLE_ENTITY
+
+
+async def tableau_http_exception_handler(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    headers = getattr(exc, "headers", None)
+    if headers:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "message": f"Server Error: {type(exc).__name__}",
+                "info": str(exc.detail),
+            },
+            headers=headers,
+        )
+    else:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "message": f"Server Error: {type(exc).__name__}",
+                "info": str(exc.detail),
+            },
+        )
+
+
+async def tableau_request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+        content={
+            "message": f"Server Error: {type(exc).__name__}",
+            "info": {str(exc)},
+        },
+    )
+
+
+async def tableau_general_exception_handler(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=HTTP_400_BAD_REQUEST,
+        content={
+            "message": f"Server Error: {type(exc).__name__}",
+            "info": {str(exc)},
+        },
+    )

--- a/fastapitableau/openapi.py
+++ b/fastapitableau/openapi.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 from typing import Dict, List, Optional
 
+from starlette.responses import HTMLResponse
+
 from fastapitableau.utils import replace_dict_keys
 
 
@@ -81,3 +83,84 @@ def rewrite_tableau_openapi(
         path_schema["$ref"] = tab_schema_ref
 
     return openapi
+
+
+# Vendored and modified from FastAPI.
+def get_swagger_ui_html(
+    *,
+    openapi_url: str,
+    title: str,
+    swagger_js_url: str = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js",
+    swagger_css_url: str = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css",
+    swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
+    home_url: str,
+) -> HTMLResponse:
+
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <link type="text/css" rel="stylesheet" href="{swagger_css_url}">
+    <link rel="shortcut icon" href="{swagger_favicon_url}">
+    <link rel="stylesheet" type="text/css" href="static/css/styles.css">
+    <title>{title}</title>
+    </head>
+    <body>
+
+    <!-- BEGIN: Insert our header into the documentation -->
+    <header class="md-header" data-md-component="header" data-md-state="shadow">
+        <nav class="md-header__inner md-grid" aria-label="Header">
+        <a href="{home_url}">
+            <label class="md-header__button md-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 122.88 113.97"><path d="M18.69,73.37,59.18,32.86c2.14-2.14,2.41-2.23,4.63,0l40.38,40.51V114h-30V86.55a3.38,3.38,0,0,0-3.37-3.37H52.08a3.38,3.38,0,0,0-3.37,3.37V114h-30V73.37ZM60.17.88,0,57.38l14.84,7.79,42.5-42.86c3.64-3.66,3.68-3.74,7.29-.16l43.41,43,14.84-7.79L62.62.79c-1.08-1-1.24-1.13-2.45.09Z"></path></svg>
+            </label>
+        </a>
+        <div class="md-header__title" data-md-component="header-title">
+            <div class="md-header__ellipsis">
+            <div class="md-header__topic">
+                <span class="md-ellipsis">
+                    FastAPI Tableau — {title}
+                </span>
+            </div>
+            </div>
+        </div>
+        </nav>
+    </header>
+    <!-- END: Insert our header into the documentation -->
+
+    <!-- BEGIN: Small container to make positions consistent between this and other pages -->
+    <div class="swagger-container">
+    <!-- END: Small container -->
+
+    <div id="swagger-ui">
+    </div>
+
+    <!-- BEGIN: Close our small container -->
+    </div>
+    <!-- END: Close small container -->
+
+    <script src="{swagger_js_url}"></script>
+    <!-- `SwaggerUIBundle` is now available on the page -->
+    <script>
+    const ui = SwaggerUIBundle({{
+        url: '{openapi_url}',
+    """
+
+    html += """
+        dom_id: '#swagger-ui',
+        presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        deepLinking: true,
+        showExtensions: true,
+        showCommonExtensions: true
+    })"""
+
+    html += """
+    </script>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)

--- a/fastapitableau/pages.py
+++ b/fastapitableau/pages.py
@@ -5,11 +5,11 @@ from commonmark import commonmark  # type: ignore[import]
 from fastapi import Request
 from fastapi.routing import APIRouter
 from pkg_resources import resource_filename
-from starlette.responses import HTMLResponse
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from fastapitableau import rstudio_connect
+from fastapitableau.openapi import get_swagger_ui_html
 from fastapitableau.user_guide import extract_routes_info
 from fastapitableau.utils import calc_app_base_url
 
@@ -85,7 +85,7 @@ async def docs_openAPI(request: Request):
     request.app.use_tableau_api_schema = False
     app_base_url = calc_app_base_url(request)
 
-    return custom_get_swagger_ui_html(
+    return get_swagger_ui_html(
         openapi_url=openapi_url,
         title="OpenAPI: Standard Web Requests",
         home_url=app_base_url,
@@ -99,89 +99,8 @@ async def docs_tableau_openAPI(request: Request):
     app_base_url = calc_app_base_url(request)
 
     request.app.use_tableau_api_schema = True
-    return custom_get_swagger_ui_html(
+    return get_swagger_ui_html(
         openapi_url=openapi_url,
         title="OpenAPI: Tableau-Style Requests",
         home_url=app_base_url,
     )
-
-
-# cloned from FastAPI library..
-def custom_get_swagger_ui_html(
-    *,
-    openapi_url: str,
-    title: str,
-    swagger_js_url: str = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js",
-    swagger_css_url: str = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css",
-    swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
-    home_url: str,
-) -> HTMLResponse:
-
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-    <link type="text/css" rel="stylesheet" href="{swagger_css_url}">
-    <link rel="shortcut icon" href="{swagger_favicon_url}">
-    <link rel="stylesheet" type="text/css" href="static/css/styles.css">
-    <title>{title}</title>
-    </head>
-    <body>
-
-    <!-- BEGIN: Insert our header into the documentation -->
-    <header class="md-header" data-md-component="header" data-md-state="shadow">
-        <nav class="md-header__inner md-grid" aria-label="Header">
-        <a href="{home_url}">
-            <label class="md-header__button md-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 122.88 113.97"><path d="M18.69,73.37,59.18,32.86c2.14-2.14,2.41-2.23,4.63,0l40.38,40.51V114h-30V86.55a3.38,3.38,0,0,0-3.37-3.37H52.08a3.38,3.38,0,0,0-3.37,3.37V114h-30V73.37ZM60.17.88,0,57.38l14.84,7.79,42.5-42.86c3.64-3.66,3.68-3.74,7.29-.16l43.41,43,14.84-7.79L62.62.79c-1.08-1-1.24-1.13-2.45.09Z"></path></svg>
-            </label>
-        </a>
-        <div class="md-header__title" data-md-component="header-title">
-            <div class="md-header__ellipsis">
-            <div class="md-header__topic">
-                <span class="md-ellipsis">
-                    FastAPI Tableau — {title}
-                </span>
-            </div>
-            </div>
-        </div>
-        </nav>
-    </header>
-    <!-- END: Insert our header into the documentation -->
-
-    <!-- BEGIN: Small container to make positions consistent between this and other pages -->
-    <div class="swagger-container">
-    <!-- END: Small container -->
-
-    <div id="swagger-ui">
-    </div>
-
-    <!-- BEGIN: Close our small container -->
-    </div>
-    <!-- END: Close small container -->
-
-    <script src="{swagger_js_url}"></script>
-    <!-- `SwaggerUIBundle` is now available on the page -->
-    <script>
-    const ui = SwaggerUIBundle({{
-        url: '{openapi_url}',
-    """
-
-    html += """
-        dom_id: '#swagger-ui',
-        presets: [
-        SwaggerUIBundle.presets.apis,
-        SwaggerUIBundle.SwaggerUIStandalonePreset
-        ],
-        layout: "BaseLayout",
-        deepLinking: true,
-        showExtensions: true,
-        showCommonExtensions: true
-    })"""
-
-    html += """
-    </script>
-    </body>
-    </html>
-    """
-    return HTMLResponse(html)


### PR DESCRIPTION
This PR adds exception handlers that format all returned exceptions in a Tableau-friendly manner. It also includes a few other misc changes.

### Exception handling

There are two special case exception handlers for `HTTPException` and `RequestValidationError`, and a general fallback for all other `Exception`s.

All exceptions are returned as JSON objects, with a `message` property containing `Server Error: [Python Exception subclass name]` and more detail in an `info` property. For example:

```bash
❯ curl -X 'POST' \
      'http://127.0.0.1:8000/evaluate' \
      -H 'accept: application/json' \
      -H 'Content-Type: application/json' \
      -d '{
          "script": "/fail",
          "data": {
                  "arg1_": ["rabbit"]
          }
  }' -i
HTTP/1.1 420
date: Thu, 23 Sep 2021 15:37:41 GMT
server: uvicorn
content-length: 52
content-type: application/json

{"message":"Server Error","info":"This didn't work"}


❯ curl -X 'POST' \
      'http://127.0.0.1:8000/fail' \
      -H 'accept: application/json' \
      -H 'Content-Type: application/json' \
      -d '{
          "first": ["Toph", "Bill", "James"]
  }'
{"message":"Server Error: RequestValidationError","info":"1 validation error for Request\nbody\n  value is not a valid list (type=type_error.list)"}
```

The special cases for RequestValidationError and HTTPException work around the fact that they contain `.detail` properties that aren't included when you run `str(exception)`, and that they imply specific error codes.

The fallback, registered for all `Exception`s, means that any error occurring in the server _should_ be sent back in a Tableau-friendly manner.

### Other changes

- Moved `get_swagger_ui_html()` to `openapi.py`.