### PR TITLE
Fix handling of large JSON bodies

### DIFF
--- a/examples/flights.py
+++ b/examples/flights.py
@@ -1,0 +1,39 @@
+from typing import List
+
+from fastapi import Request
+
+from fastapitableau import FastAPITableau
+
+app = FastAPITableau(
+    title="Simple Example",
+    description="A *simple* example FastAPITableau app.",
+    version="0.1.0",
+)
+
+
+@app.post("/flights")
+def flights(
+    year: List[str],
+    month: List[str],
+    day: List[str],
+    dep_time: List[str],
+    sched_dep_time: List[str],
+) -> List[str]:
+    return ["Yes"]
+
+
+@app.post("/paste")
+def paste(first: List[str], second: List[str]) -> List[str]:
+    result = [a + " " + b for a, b in zip(first, second)]
+    return result
+
+
+@app.post("/capitalize")
+def capitalize(text: List[str]) -> List[str]:
+    capitalized = [t.upper() for t in text]
+    return capitalized
+
+
+@app.post("/test")
+async def test(req: Request):
+    return await req.json()

--- a/fastapitableau/middleware.py
+++ b/fastapitableau/middleware.py
@@ -22,7 +22,20 @@ class TableauExtensionMiddleware:
 
     @staticmethod
     async def rewrite_scope_path(scope: Dict, receive: Receive) -> Tuple[Dict, Receive]:
-        event = await receive()
+        # Consume and gather event body
+        message_body = b""
+        more_body = True
+        while more_body:
+            message = await receive()
+            message_body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        event = {
+            "type": message.get("type", "http.request"),
+            "body": message_body,
+            "more_body": more_body,
+        }
+
         print(event)
 
         body = json.loads(event["body"])

--- a/fastapitableau/routing.py
+++ b/fastapitableau/routing.py
@@ -27,9 +27,13 @@ class TableauRoute(APIRoute):
             data = body["data"]
             if len(data) == 1:
                 _body = list(data.values())[0]
-            elif len(data) > 1:
-                new_keys = [param.name for param in self.dependant.body_params]
+            elif len(data) > 1 and "_arg1" in data.keys():
+                new_keys: Dict[str, str] = {}
+                for i, param in enumerate(self.dependant.body_params):
+                    new_keys["_arg" + str(i + 1)] = param.name
                 _body = replace_dict_keys(data, new_keys)
+            else:
+                _body = data
             event["body"] = bytes(json.dumps(_body), encoding="utf-8")
 
         async def _receive():

--- a/fastapitableau/user_guide.py
+++ b/fastapitableau/user_guide.py
@@ -86,7 +86,8 @@ class RouteInfo:
         }
 
         if self.return_info.type not in tableau_funcs.keys():
-            raise TypeError("Unexpected return type: %s" % (self.return_info.type))
+            return f"Cannot determine Tableau script for return type '{self.return_info.type}'"
+            # raise TypeError(f"Cannot determine Tableau script for return type for function at '{self.path}': {self.return_info.type}")
         else:
             tableau_func = tableau_funcs[self.return_info.type]
 

--- a/fastapitableau/utils.py
+++ b/fastapitableau/utils.py
@@ -1,13 +1,13 @@
-from typing import Dict, List
+from typing import Dict
 
 from fastapi import Request
 
 
-def replace_dict_keys(d: Dict, new_keys: List):
-    old_keys = sorted(d.keys())
-    for old, new in zip(old_keys, new_keys):
-        d[new] = d.pop(old)
-    return d
+def replace_dict_keys(old_dict: Dict, new_keys: Dict[str, str]):
+    new_dict: Dict = {}
+    for old, new in new_keys.items():
+        new_dict[new] = old_dict[old]
+    return new_dict
 
 
 def remove_prefix(text, prefix):


### PR DESCRIPTION
Addresses https://github.com/rstudio/connect/issues/19982

### Problem

FastAPI Tableau would fail on large JSON bodies.

### Solution

Added proper functionality to handle long async requests. The Middleware now consumes the entire request event properly.

### Other Changes

This PR contains other changes:

- `replace_dict_keys()` used to take a simple list of new keys. This could cause problems — if any old keys were the same as new keys, it could lead to deletion or unintended re-ordering. Now it requires a dict explicitly mapping old keys to new keys, as in `{"old_key": "new_key"}`. I rewrote the places where it's called to generate the key map.
- The user guide used to fail to render if a function didn't have a defined return type. Now it displays a warning message instead of the Tableau copy-and-paste function.
- The Tableau OpenAPI docs used to fail to build if a function took the entire Request as its input. Now it is just not rewritten.