### PR TITLE
Update documentation about self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ def paste(first: List[str], second: List[str]) -> List[str]:
 
 This metadata will appear in the documentation for Tableau users.
 
-## Deploying extensions to RStudio Connect.
+## Deploying extensions to RStudio Connect
 
 You can deploy FastAPI Tableau extensions to RStudio Connect with `rsconnect-python`. Detailed documentation can be found [over there](https://github.com/rstudio/rsconnect-python#deploying-python-content-to-rstudio-connect).
 
@@ -120,6 +120,14 @@ rsconnect deploy fastapi \
 ```
 
 rsconnect-python assumes that your API is the only Python in its directory. For best results, specify your API's dependencies in a `requirements.txt` file in the same directory. See more information [here](https://github.com/rstudio/rsconnect-python#package-dependencies-1).
+
+### Using self-signed certificates
+
+When using self-signed certificates with FastAPI Tableau, you must make Python aware of the path to the certificate.
+
+Set the `REQUESTS_CA_BUNDLE` environment variable to the path to your certificate file. This variable is used by the underlying Requests library, and is documented [here](https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification).
+
+In RStudio Connect, set the environment variable [in the Vars tab of the Content Settings Panel](https://docs.rstudio.com/connect/user/content-settings/#content-vars). Note that applications running on RStudio Connect cannot access the `/etc` directory, so the certificate must be in a different location, such as `/opt/python`.
 
 ## Calling an extension endpoint in Tableau
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ def paste(first: List[str], second: List[str]) -> List[str]:
 
 This metadata will appear in the documentation for Tableau users.
 
-## Deploying extensions to RStudio Connect.
+## Deploying extensions to RStudio Connect
 
 You can deploy FastAPI Tableau extensions to RStudio Connect with `rsconnect-python`. Detailed documentation can be found [over there](https://github.com/rstudio/rsconnect-python#deploying-python-content-to-rstudio-connect).
 
@@ -120,6 +120,14 @@ rsconnect deploy fastapi \
 ```
 
 rsconnect-python assumes that your API is the only Python in its directory. For best results, specify your API's dependencies in a `requirements.txt` file in the same directory. See more information [here](https://github.com/rstudio/rsconnect-python#package-dependencies-1).
+
+### Using self-signed certificates
+
+When using self-signed certificates with FastAPI Tableau, you must make Python aware of the path to the certificate.
+
+Set the `REQUESTS_CA_BUNDLE` environment variable to the path to your certificate file. This variable is used by the underlying Requests library, and is documented [here](https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification).
+
+In RStudio Connect, set the environment variable [in the Vars tab of the Content Settings Panel](https://docs.rstudio.com/connect/user/content-settings/#content-vars). Note that applications running on RStudio Connect cannot access the `/etc` directory, so the certificate must be in a different location, such as `/opt/python`.
 
 ## Calling an extension endpoint in Tableau
 

--- a/fastapitableau/rstudio_connect.py
+++ b/fastapitableau/rstudio_connect.py
@@ -100,7 +100,8 @@ def warning_message() -> Optional[str]:  # noqa: C901
             "\n- Confirm there is connectivity between the server itself and the address assigned to it: "
             f"{connect_server}"
             "."
-            "\n- If using HTTPS along with self-signed certificates, you may need to allow the FastAPITableau package to use HTTP instead, by setting the environment variable `FASTAPITABLEAU_USE_HTTP` to `True` in the RStudio Connect application settings."
+            "\n- If using HTTPS with self-signed certificates, you need to tell Python about the location of your certificate file. In RStudio Connect, set the `REQUESTS_CA_BUNDLE` environment variable to the path to your certificate file, in the Vars tab of the Content Settings Panel. "
+            "Note that applications on RStudio Connect cannot access `/etc` directory, so the certificate must be located elsewhere, such as `/opt/python`."
         )
     else:
         # Only execute if response exists


### PR DESCRIPTION
## Description

You can use self-signed certificates with FastAPI-Tableau by using the Requests library's `REQUESTS_CA_BUNDLE` environment variable. This PR changes the documentation to reflect that — in the extension itself, the README.md file, and the MkDocs file.

In action, the changes looks somewhat like the following. Ignore the "name 'connect_api_key' is not defined" error — that was me hacking at stuff to get the other warning message to show. In addition, I removed the word "along" from the final bullet point before committing.

![Screen Shot 2022-02-23 at 01 23 44 PM@2x](https://user-images.githubusercontent.com/3117884/155384793-19a7e802-4fbf-4613-bc0f-fa74b2975c74.png)

### QA / Testing Notes

None really — no actual code was changed.

### Notes

Once this PR is approved, I'll publish a patch release so that people using the package have the new warning message, and I'll update the docs site.