### PR TITLE
Pin FastAPI to avoid Pydantic 2.0 breakages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2
@@ -38,6 +38,7 @@ jobs:
         pipenv install --dev --skip-lock
 
     - name: Lint
+      if: matrix.python-version == 3.9
       run: just lint
 
     - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- FastAPI-Tableau now requires FastAPI <= 0.88.0 to avoid compatibility issues.
+
 ## [1.1.1] - 2022-02-23
+
+### Changed
 
 - Changed warning message upon HTTPS failure, with new directions for self-signed certificate use.
 

--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ twine = "*"
 build = "*"
 mkdocs-material = "*"
 pytest-asyncio = "*"
+httpx = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -4,14 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-fastapi = "*"
-uvicorn = {extras = ["standard"], version = "*"}
 fastapitableau = {editable = true, path = "."}
-aiofiles = "*"
-commonmark = "*"
-requests = "*"
 
 [dev-packages]
+uvicorn = {extras = ["standard"], version = "*"}
 black = "*"
 pytest = "*"
 flake8 = "*"

--- a/fastapitableau/logger.py
+++ b/fastapitableau/logger.py
@@ -24,7 +24,9 @@ class ScopeAdapter(logging.LoggerAdapter):
             return prefix + msg, kwargs
 
 
-def get_correlation_id(scope: Scope = None, headers: Headers = None) -> Optional[str]:
+def get_correlation_id(
+    scope: Optional[Scope] = None, headers: Optional[Headers] = None
+) -> Optional[str]:
     headers = Headers(scope=scope, headers=headers)
     correlation_id_keys = ["x-rs-correlation-id", "x-correlation-id"]
     for key in correlation_id_keys:

--- a/fastapitableau/openapi.py
+++ b/fastapitableau/openapi.py
@@ -16,7 +16,6 @@ def rewrite_tableau_openapi(
         rewrite_paths = list(openapi["paths"].keys())
 
     for path_name in rewrite_paths:
-
         path = openapi["paths"][path_name]
         request_body = path.get("post").get("requestBody")
 
@@ -96,7 +95,6 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     home_url: str,
 ) -> HTMLResponse:
-
     html = f"""
 <!DOCTYPE html>
     <html>

--- a/fastapitableau/routing.py
+++ b/fastapitableau/routing.py
@@ -69,7 +69,7 @@ class TableauRoute(APIRoute):
         return custom_route_handler
 
     async def ensure_request_body(
-        self, body: Dict, scope: MutableMapping = None
+        self, body: Dict, scope: Optional[MutableMapping] = None
     ) -> Dict:
         # Here, we only want to operate on Tableau requests. We have a few options.
         # 1. Duck typing, which is what the main branch does right now. It checks to see if this a dict and contains the keys "script" and "data".

--- a/fastapitableau/rstudio_connect.py
+++ b/fastapitableau/rstudio_connect.py
@@ -82,7 +82,7 @@ def warning_message() -> Optional[str]:  # noqa: C901
         # Call RStudio Connect API to get server settings
         use_http = environ.get("FASTAPITABLEAU_USE_HTTP", "False").title() == "True"
         if use_http:
-            connect_server = urlparse(connect_server)._replace(scheme="http").geturl()  # type: ignore[arg-type]
+            connect_server = urlparse(connect_server)._replace(scheme="http").geturl()  # type: ignore[arg-type, assignment]
         settings_url = str(connect_server) + "__api__/server_settings"
         headers = {"Authorization": "Key " + str(connect_api_key)}
         response = requests.get(settings_url, headers=headers, verify=not use_http)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 install_requires =
-    fastapi <=0.99.1
+    fastapi <=0.88.0
     aiofiles
     commonmark
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 install_requires =
-    fastapi
+    fastapi <=0.99.1
     aiofiles
     commonmark
     requests

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -14,6 +14,7 @@ paste_body_tableau = {
     "data": {"_arg1": ["A", "B", "C"], "_arg2": ["D", "E", "F"]},
 }
 
+
 # In some of the tests, the "script" arg will differ from the actual path, but
 # that won't matter.
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

FastAPI has updated to support Pydantic 2.0. This causes major issues that'll require a larger reworking. In the meantime, we're pinning to the latest FastAPI version that causes no tests to break.

### Solution

- Pin to FastAPI `0.87.0`. Newer versions cause small test failures; `0.100.0` causes major issues.
- Update CI to test on more modern Python versions.

## Testing Notes / Validation Steps

Tests affirm that stuff still works. I also validated manually that APIs can be served.