### PR TITLE
Test against latest FastAPI

### DIFF
--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade pipenv wheel
 
-    - name: Install dependencies and latest FastAPI
+    - name: Install dependencies, upgrade FastAPI
       run: |
         pipenv install --dev --skip-lock
         pip install --upgrade fastapi

--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test Latest FastAPI
 
 on:
   push:
@@ -6,9 +6,12 @@ on:
     tags: ['*']
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 13 * * 1' # Every Monday at 13:00 UTC
 
 jobs:
   test:
+
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,30 +35,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade pipenv wheel
 
-    - name: Install dependencies
+    - name: Install dependencies and latest FastAPI
       run: |
         pipenv install --dev --skip-lock
-
-    - name: Lint
-      if: matrix.python-version == 3.9
-      run: just lint
+        pip install --upgrade fastapi
+        pip list
 
     - name: Test
       run: just test
-
-    - name: Generate coverage report
-      if: matrix.python-version == 3.9
-      run: |
-        pipenv run pytest --cov=./ --cov-report=xml
-
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.9
-      uses: codecov/codecov-action@v2
-      with:
-        fail_ci_if_error: true
-        files: ./coverage.xml
-        flags: unittests
-
-    - name: Publish MkDocs
-      if: github.ref == 'refs/heads/main' && matrix.python-version == 3.9
-      run: pipenv run mkdocs gh-deploy --force


### PR DESCRIPTION
## Description

CI adjustments.

- Added Python 3.12 to all workflows.
- Added a new workflow, "Test Latest FastAPI", which sets up a dev environment and runs tests. It is similar to the CI workflow, with a few differences:
  - Skips linting.
  - Before running the tests, it runs `pip install --upgrade fastapi`, which installs the latest FastAPI, despite it being pinned by FastAPI-Tableau to an earlier version.
  - Scheduled to run every Monday at 1:00 PM UTC (9 AM EDT).

Ideally, this workflow will fail when we break on the latest FastAPI, giving us a heads-up that updating to the latest FastAPI will require changes.

Right now, Pip prints a message about the dependency conflict but does not prevent the upgrade. It is possible that future versions of Pip will prevent this "breaking" upgrade. If that happens, we might need to use a tool like [tox](https://tox.wiki/en/latest/).

## Testing Notes / Validation Steps

N/A; CI change only.