### PR TITLE
Update to latest versions of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: extractions/setup-just@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -50,7 +50,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.9
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
         files: ./coverage.xml

--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -19,14 +19,14 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: extractions/setup-just@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Description

Recently CI was broken due to a change in GitHub Actions runners ([link](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)).

This PR takes the latest non-beta version of all actions in use.

## Testing Notes / Validation Steps

This is a CI-only change.
