### PR TITLE
feat: set install requires fastapi >= 0.103.1

### DIFF
--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -2,7 +2,7 @@ name: Test Latest FastAPI
 
 on:
   push:
-    branches: [main, tdstein]
+    branches: [main]
     tags: ['*']
   pull_request:
     branches: [main]

--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -2,7 +2,7 @@ name: Test Latest FastAPI
 
 on:
   push:
-    branches: [main]
+    branches: [main, tdstein]
     tags: ['*']
   pull_request:
     branches: [main]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 install_requires =
-    fastapi ==0.103.1
+    fastapi>=0.103.1
     aiofiles
     commonmark
     requests


### PR DESCRIPTION
Synk reports a Regular Expression Denial of Service (ReDoS) vulnerability in FastAPI 0.103.1. Therefore, consumers should be allowed to upgrade to a newer version of FastAPI at their discretion.