### PR TITLE
Chore: pin fastapi and httpx to compatibile versions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 fastapitableau = {editable = true, path = "."}
 
 [dev-packages]
+fastapi = "==0.110.3"
 uvicorn = {extras = ["standard"], version = "*"}
 black = "*"
 pytest = "*"
@@ -24,7 +25,7 @@ twine = "*"
 build = "*"
 mkdocs-material = "*"
 pytest-asyncio = "*"
-httpx = "*"
+httpx = "==0.24.1"
 
 [pipenv]
 allow_prereleases = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 install_requires =
-    fastapi>=0.103.1
+    fastapi>=0.103.1,<0.111
     aiofiles
     commonmark
     requests


### PR DESCRIPTION
## Description

Some Connect `rsconnect-python` deployment tests failed for `fastapitableau` which lead me here to try to find a fix.

Addresses #48

### Problem

The latest `fastapi` has an incompatability with `fastapitableau`

### Solution

- Pin to the last know compatible version of `fastapi`
- Also pin to a known compatibile version of `httpx` which appears to be used in testing only

Otherwise `fastapitableau` will need code changes to work with the very latest versions of these dependencies.

## Testing Notes / Validation Steps

All tests should pass

```
pipenv --rm
rm -f Pipfile.lock
pipenv install --dev
just test
```
