### PR TITLE
fix: fix middleware request routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
       if: matrix.python-version == 3.9
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         files: ./coverage.xml
         flags: unittests
 

--- a/.github/workflows/test-latest-fastapi.yml
+++ b/.github/workflows/test-latest-fastapi.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed middleware not matching `/evaluate` on RStudio Connect, where `scope["path"]` includes the content prefix (e.g. `/content/<guid>/evaluate`). The middleware now strips `root_path` before matching, consistent with how FastAPI resolves routes behind a proxy. ([#51](https://github.com/rstudio/fastapitableau/issues/51))
+- Fixed middleware to copy the ASGI scope dictionary instead of mutating the original.
+- Replaced deprecated `pkg_resources` usage with `importlib.resources` for Python 3.12+ compatibility.
+- Replaced internal `fastapi._compat` imports with direct Pydantic v2 APIs for forward compatibility with newer FastAPI versions.
+- Fixed compatibility with FastAPI 0.135+ where `ModelField` no longer has `type_` or `required` attributes.
+- Fixed `TemplateResponse` calls for modern Starlette (request as first argument).
+
+### Changed
+
+- Minimum supported Python version is now 3.9 (was 3.7).
+
 ## [1.3.0] - 2024-08-30
 
 - Install requires fastapi >= 0.103.1

--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,6 @@ pytest-cov = "*"
 isort = "*"
 pre-commit = "*"
 ipython = "*"
-typed-ast = "*"
 types-requests = "*"
 types-setuptools = "*"
 twine = "*"
@@ -25,6 +24,3 @@ build = "*"
 mkdocs-material = "*"
 pytest-asyncio = "*"
 httpx = "*"
-
-[pipenv]
-allow_prereleases = true

--- a/fastapitableau/middleware.py
+++ b/fastapitableau/middleware.py
@@ -19,7 +19,13 @@ class TableauExtensionMiddleware:
 
     async def __call__(self, scope, receive, send) -> None:
         logger.debug("Received request with scope: %s", scope, extra={"scope": scope})
-        if scope["type"] == "http" and scope["path"] == "/evaluate":
+        # Strip root_path (e.g. /content/<guid>) to get the app-relative path,
+        # matching how FastAPI/Starlette resolve routes behind a proxy.
+        path = scope.get("path", "")
+        root_path = scope.get("root_path", "")
+        if root_path and path.startswith(root_path):
+            path = path[len(root_path) :]
+        if scope["type"] == "http" and path == "/evaluate":
             _scope, _receive = await self.rewrite_scope_path(scope, receive)
             await self.app(_scope, _receive, send)
         else:
@@ -48,10 +54,14 @@ class TableauExtensionMiddleware:
             extra={"scope": scope},
         )
 
-        scope["path"] = target_path
-        scope["raw_path"] = bytes(target_path, encoding="utf-8")
+        # Shallow copy is sufficient here because we only replace immutable
+        # values (str, bytes). Do not mutate nested structures (e.g. headers,
+        # state) on new_scope — they are shared with the original.
+        new_scope = scope.copy()
+        new_scope["path"] = target_path
+        new_scope["raw_path"] = bytes(target_path, encoding="utf-8")
 
         async def _receive():
             return event
 
-        return scope, _receive
+        return new_scope, _receive

--- a/fastapitableau/pages.py
+++ b/fastapitableau/pages.py
@@ -1,10 +1,10 @@
 import os
+from importlib.resources import files
 from urllib.parse import urlparse
 
 from commonmark import commonmark  # type: ignore[import]
 from fastapi import Request
 from fastapi.routing import APIRouter
-from pkg_resources import resource_filename
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
@@ -19,7 +19,7 @@ def markdown_filter(text):
     return commonmark(text)
 
 
-templates_directory = resource_filename("fastapitableau", "templates")
+templates_directory = str(files("fastapitableau").joinpath("templates"))
 
 statics = StaticFiles(packages=["fastapitableau"])
 jinja_templates = Jinja2Templates(directory=templates_directory)
@@ -35,7 +35,7 @@ async def home(request: Request):
         "warning_message": rstudio_connect.warning_message(),
         "app_base_url": calc_app_base_url(request),
     }
-    return jinja_templates.TemplateResponse("index.html", context=context)
+    return jinja_templates.TemplateResponse(request, "index.html", context=context)
 
 
 @built_in_pages.get("/setup_tableau", include_in_schema=False)
@@ -60,7 +60,9 @@ async def setup(request: Request):
         "server_port": server_port,
         "app_base_url": calc_app_base_url(request),
     }
-    return jinja_templates.TemplateResponse("setup_tableau.html", context=context)
+    return jinja_templates.TemplateResponse(
+        request, "setup_tableau.html", context=context
+    )
 
 
 @built_in_pages.get("/tableau_usage", include_in_schema=False)
@@ -76,7 +78,9 @@ async def tableau_usage(request: Request):
         "routes_info": routes_info,
         "app_base_url": calc_app_base_url(request),
     }
-    return jinja_templates.TemplateResponse("tableau_usage.html", context=context)
+    return jinja_templates.TemplateResponse(
+        request, "tableau_usage.html", context=context
+    )
 
 
 # We're bypassing the built-in generation of the docs so we can show two different

--- a/fastapitableau/routing.py
+++ b/fastapitableau/routing.py
@@ -2,51 +2,39 @@ import json
 from typing import Any, Callable, Dict, MutableMapping, Optional
 
 from fastapi import Request, Response
-from fastapi._compat import (
-    GenerateJsonSchema,
-    get_compat_model_name_map,
-    get_definitions,
-    get_schema_from_model_field,
-)
-from fastapi.dependencies.utils import request_body_to_args
 from fastapi.exceptions import RequestValidationError
-from fastapi.openapi.utils import get_fields_from_routes
 from fastapi.routing import APIRoute
+from pydantic import TypeAdapter, ValidationError
 
 from fastapitableau.logger import logger
-from fastapitableau.utils import event_from_receive, remove_prefix, replace_dict_keys
+from fastapitableau.utils import event_from_receive, replace_dict_keys
 
 
 class TableauRoute(APIRoute):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._body_schema: Optional[Dict[str, Any]] = None
+        self._body_type_adapter: Optional[TypeAdapter] = None
+        if self.body_field is not None:
+            if hasattr(self.body_field, "_type_adapter"):
+                self._body_type_adapter = self.body_field._type_adapter
+            else:
+                self._body_type_adapter = TypeAdapter(self.body_field.type_)
 
     def get_body_field_schema(self):
-        # schema, definitions, nested models
-        route_fields = get_fields_from_routes([self])
-        route_model_name_map = get_compat_model_name_map(route_fields)
-        schema_generator = GenerateJsonSchema()
-        field_mapping, definitions = get_definitions(
-            fields=route_fields,
-            schema_generator=schema_generator,
-            model_name_map=route_model_name_map,
-        )
-        body_field_schema = get_schema_from_model_field(
-            field=self.body_field,
-            schema_generator=GenerateJsonSchema,
-            model_name_map=route_model_name_map,
-            field_mapping=field_mapping,
-        )
-        return body_field_schema, definitions
+        if self._body_type_adapter is None:
+            return {}, {}
+        schema = self._body_type_adapter.json_schema()
+        definitions = schema.pop("$defs", {})
+        return schema, definitions
 
     @property
     def body_schema(self):
         if not self._body_schema:
             f_schema, f_definitions = self.get_body_field_schema()
 
-            if "$ref" in f_schema.keys():
-                ref = remove_prefix(f_schema["$ref"], "#/$defs/")
+            if "$ref" in f_schema:
+                ref = f_schema["$ref"].removeprefix("#/$defs/")
                 definition = f_definitions[ref]
             else:
                 definition = f_schema
@@ -93,7 +81,7 @@ class TableauRoute(APIRoute):
         Rewrites requests that look like they come from Tableau into ordinary
         requests. Leave other requests unchanged.
         """
-        body_will_validate = await self.body_will_validate(body)
+        body_will_validate = self.body_will_validate(body)
         if body_will_validate:
             _body = body
             logger.debug(
@@ -139,9 +127,15 @@ class TableauRoute(APIRoute):
             )
         return _body
 
-    async def body_will_validate(self, body: Dict[str, Any]):
+    def body_will_validate(self, body: Any) -> bool:
         """
-        This function tries to process the request body using FastAPI's own function, and returns False if it fails to process. It's potentially expensive, but could be useful as a stricter heuristic for deciding whether to rewrite the request body.
+        Check whether the body will pass validation against the route's expected
+        type. Returns True if valid (no rewriting needed), False otherwise.
         """
-        values, errors = await request_body_to_args(self.dependant.body_params, body)
-        return False if errors else True
+        if self._body_type_adapter is None:
+            return True
+        try:
+            self._body_type_adapter.validate_python(body)
+            return True
+        except ValidationError:
+            return False

--- a/fastapitableau/user_guide.py
+++ b/fastapitableau/user_guide.py
@@ -3,7 +3,6 @@ from inspect import Signature, signature
 from typing import Any, List, Optional
 from urllib.parse import urljoin, urlparse
 
-from fastapi._compat import ModelField
 from pydantic._internal._repr import display_as_type
 from pydantic_core import PydanticUndefined
 
@@ -20,11 +19,16 @@ class ParamInfo:
     default: Any
     details: str
 
-    def __init__(self, param: ModelField):
+    def __init__(self, param: Any):
         self.name = param.name
-        self.type = display_as_type(param.type_)
+        field_type = getattr(param, "type_", None) or param.field_info.annotation
+        self.type = display_as_type(field_type)
         self.tableau_type = tableau_name_for_python_type(self.type)
-        self.required = param.required
+        self.required = (
+            param.required
+            if hasattr(param, "required")
+            else param.field_info.is_required()
+        )
         self.default = param.default
         self.details = self._details()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py37']
+target-version = ['py39']
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,20 +15,24 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 install_requires =
-    fastapi>=0.103.1
+    fastapi>=0.109.1
     aiofiles
     commonmark
     requests
     jinja2
-setup_requires = setuptools
+setup_requires = setuptools>=45
 packages = fastapitableau
-python_requires = >=3.7
+python_requires = >=3.9
 zip_safe = True
 include_package_data = True
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -67,14 +67,14 @@ def test_failure():
 
 def test_single_arg_endpoint_tableau():
     data = make_data("/capitalize", [["dog", "cat", "bunny"]])
-    response = client.post("/evaluate", data=data)
+    response = client.post("/evaluate", json=json.loads(data))
     assert response.status_code == 200
     assert response.json() == ["DOG", "CAT", "BUNNY"]
 
 
 def test_multi_arg_endpoint_tableau():
     data = make_data("/paste", [["big", "small", "fluffy"], ["dog", "cat", "bunny"]])
-    response = client.post("/evaluate", data=data)
+    response = client.post("/evaluate", json=json.loads(data))
     assert response.status_code == 200
     assert response.json() == [
         "big dog",
@@ -85,7 +85,7 @@ def test_multi_arg_endpoint_tableau():
 
 def test_variadic_endpoint():
     data = make_data("/variadic", [["big", "small", "fluffy"], ["dog", "cat", "bunny"]])
-    response = client.post("/evaluate", data=data)
+    response = client.post("/evaluate", json=json.loads(data))
     assert response.status_code == 200
     assert response.json() == json.loads(data)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import pytest  # noqa: F401
@@ -12,7 +13,7 @@ def test_evaluate_request_logs_with_correlation_id(caplog):
 
     cid = "02224a4a-9f85-4c10-9223-c5bc92258882"
     data = make_data("/paste", [["big", "small", "fluffy"], ["dog", "cat", "bunny"]])
-    client.post("/evaluate", headers={"x-correlation-id": cid}, data=data)
+    client.post("/evaluate", headers={"x-correlation-id": cid}, json=json.loads(data))
     assert cid in caplog.text
     assert "Rewriting" in caplog.text
 
@@ -23,6 +24,6 @@ def test_no_logging(caplog):
 
     cid = "02224a4a-9f85-4c10-9223-c5bc92258882"
     data = make_data("/paste", [["big", "small", "fluffy"], ["dog", "cat", "bunny"]])
-    client.post("/evaluate", headers={"x-correlation-id": cid}, data=data)
+    client.post("/evaluate", headers={"x-correlation-id": cid}, json=json.loads(data))
     assert cid not in caplog.text
     assert "Rewriting" not in caplog.text

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+
+from fastapitableau.middleware import TableauExtensionMiddleware
+
+
+@pytest.mark.asyncio
+async def test_rewrite_scope_path_does_not_mutate_original():
+    """
+    Regression test for #51: the middleware must not mutate the original
+    ASGI scope dict. A shallow copy is made instead so that upstream middleware
+    still sees the original path.
+    """
+    original_scope = {
+        "type": "http",
+        "path": "/evaluate",
+        "raw_path": b"/evaluate",
+        "headers": [],
+    }
+    body = json.dumps({"script": "/capitalize", "data": {"_arg1": ["hello"]}})
+
+    async def mock_receive():
+        return {"type": "http.request", "body": body.encode(), "more_body": False}
+
+    new_scope, _ = await TableauExtensionMiddleware.rewrite_scope_path(
+        original_scope, mock_receive
+    )
+
+    # The original scope must be unchanged
+    assert original_scope["path"] == "/evaluate"
+    assert original_scope["raw_path"] == b"/evaluate"
+
+    # The new scope has the rewritten path
+    assert new_scope["path"] == "/capitalize"
+    assert new_scope["raw_path"] == b"/capitalize"
+
+    # They are distinct dicts
+    assert new_scope is not original_scope


### PR DESCRIPTION
Fix #51. Since Connect [2024.11.0](https://docs.posit.co/connect/news/#posit-connect-2024.11.0-fixed), FastAPI applications receive `scope["path"]` as the full content URL (e.g. `/content/<guid>/evaluate`) rather than the path relative to the content mount point (e.g. `/evaluate`). The Tableau middleware was doing a naive `scope["path"] == "/evaluate"` check, so it never matched and requests to `/evaluate` 404'd.

I had to also make some other updates to places where the codebase relied on deprecated or internal APIs that broke with recent versions of python, fastapi, and starlette. I've updated our CI matrix as well. 