### PR TITLE
chore: prep 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.0] - 2026-04-14
 
 ### Fixed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fastapitableau
-version = 1.3.0
+version = 1.4.0
 url = https://github.com/rstudio/fastapitableau
 license = MIT
 license_files = LICENSE.txt


### PR DESCRIPTION
update changelog and setup.cfg with the new, to-be-released version
